### PR TITLE
add initial smoke tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /.pnp
 .pnp.js
 .eslintcache
+/.vscode
 
 # testing
 /coverage
@@ -18,6 +19,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.env*
 
 npm-debug.log*
 yarn-debug.log*

--- a/package.json
+++ b/package.json
@@ -242,5 +242,9 @@
 			"last 1 firefox version",
 			"last 1 safari version"
 		]
+	},
+	"jest": {
+		"resetMocks": false,
+		"resetModules": false
 	}
 }

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,41 @@
-import { render, screen } from "@testing-library/react";
+import { render } from "./testing/customRender";
 import App from "./App";
 
-test("renders learn react link", () => {
-	render(<App />);
-	const linkElement = screen.getByText(/learn react/i);
-	expect(linkElement).toBeInTheDocument();
+jest.mock("./state/lists/updater", () => jest.fn());
+jest.mock("./theme", () => ({
+	FixedGlobalStyle: () => "FixedGlobalStyle",
+	ThemedGlobalStyle: () => "ThemedGlobalStyle",
+}));
+
+jest.mock("./components/RouteChanger/routeChanger", () => () => <div>RouteChanger</div>);
+jest.mock("./components/WalletModal", () => () => <div>WalletModal</div>);
+jest.mock("./state/lists/updater", () => () => <div>ListsUpdater</div>);
+jest.mock("./state/application/updater", () => () => <div>ApplicationUpdater</div>);
+jest.mock("./state/multicall/updater", () => () => <div>MultiCallUpdater</div>);
+jest.mock("./state/transactions/updater", () => () => <div>TransactionUpdater</div>);
+jest.mock("./state/user/updater", () => () => <div>UserUpdater</div>);
+jest.mock("./Routes", () => () => <div>Routes</div>);
+jest.mock("./components/Web3ReactManager", () => ({ children }) => <div>Web3ReactManager {children}</div>);
+jest.mock("./components/TransactionHandler", () => () => <div>TransactionHandler</div>);
+
+let state = {
+	initialState: {
+		user: {
+			userDarkMode: false,
+		},
+	},
+};
+
+test("smoke test light mode", () => {
+	render(<App />, state);
+});
+
+test("smoke test dark mode", () => {
+	state.initialState.user.userDarkMode = true;
+	render(<App />, state);
+});
+
+test("requires user state", () => {
+	state.initialState.user = null;
+	expect(() => render(<App />, state)).toThrow();
 });

--- a/src/testing/customRender.js
+++ b/src/testing/customRender.js
@@ -1,0 +1,48 @@
+import React from "react";
+import { Provider } from "react-redux";
+import { render } from "@testing-library/react";
+import "inter-ui";
+import { createWeb3ReactRoot, Web3ReactProvider } from "@web3-react/core";
+import getLibrary from "../utils/getLibrary";
+import { NetworkContextName } from "../constants";
+import "../i18n";
+import { createStore } from "redux";
+import { reducer } from "./testReducer";
+
+const Web3ProviderNetwork = createWeb3ReactRoot(NetworkContextName);
+
+jest.mock("@web3-react/ledger-connector", () => ({
+	LedgerConnector: jest.fn(() => ({})),
+}));
+
+jest.mock("@web3-react/trezor-connector", () => ({
+	TrezorConnector: jest.fn(() => ({})),
+}));
+
+jest.mock("@web3-react/torus-connector", () => ({
+	TorusConnector: jest.fn(() => ({})),
+}));
+
+jest.mock("@web3-react/portis-connector", () => ({
+	PortisConnector: jest.fn(() => ({})),
+}));
+
+const customRender = (ui, { initialState, store = createStore(reducer, initialState), ...renderOptions } = {}) => {
+	const Wrapper = ({ children }) => {
+		return (
+			<React.StrictMode>
+				<Web3ReactProvider getLibrary={getLibrary}>
+					<Web3ProviderNetwork getLibrary={getLibrary}>
+						<Provider store={store}>{children}</Provider>
+					</Web3ProviderNetwork>
+				</Web3ReactProvider>
+			</React.StrictMode>
+		);
+	};
+
+	return render(ui, { wrapper: Wrapper, ...renderOptions });
+};
+
+export * from "@testing-library/react";
+
+export { customRender as render };

--- a/src/testing/testReducer.js
+++ b/src/testing/testReducer.js
@@ -1,0 +1,3 @@
+export const reducer = (state, action) => {
+	return state;
+};


### PR DESCRIPTION
This is an initial set of smoke tests to show that:

1. The main App component can be rendered with providers
2. The redux store state can be provided to components
3. Allow easy mocking of reducers

Please create a .env.test file to make sure that config is read properly while running tests